### PR TITLE
Fixed typo in populate.py

### DIFF
--- a/zeeguu/populate.py
+++ b/zeeguu/populate.py
@@ -16,7 +16,7 @@ if __name__ == "__main__":
     print ("!!!! in populate...")
     zeeguu.app = Flask("Zeeguu-Core-Test")
 
-    config_file = os.path.expanduser('~/./config/zeeguu/core.cfg')
+    config_file = os.path.expanduser('~/.config/zeeguu/core.cfg')
     if os.environ.has_key("CONFIG_FILE"):
         config_file = os.environ["CONFIG_FILE"]
     zeeguu.app.config.from_pyfile(config_file, silent=False)  # config.cfg is in the instance folder

--- a/zeeguu/populate.py
+++ b/zeeguu/populate.py
@@ -32,6 +32,7 @@ from zeeguu.model.user_word import UserWord
 from zeeguu.model.bookmark import Bookmark
 from zeeguu.model.language import Language
 from zeeguu.model.user import User
+from zeeguu.model.unique_code import UniqueCode
 
 WORD_PATTERN = re.compile("\[?([^{\[]+)\]?( {[^}]+})?( \[[^\]]\])?")
 


### PR DESCRIPTION
I think you accidentally added a slash here where it shouldn't be